### PR TITLE
build: add .gitattributes config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.ts text eol=lf
+*.js test eol=lf
+.kokoro/* linguist-vendored
+*.js linguist-language=TypeScript


### PR DESCRIPTION
As we start moving away from `repos.json` to track the list of available repositories, we need to rely on GitHub detecting our repositories as TypeScript or JavaScript.  In some rare cases, due to the number of shell scripts used by Kokoro, linguist is detecting repositories as Shell.  Comically, both `autosynth` and  `@google/repo` are now using the language field in the repository to determine which repositories are in scope.  That means from time to time, we need to manually (like this) fix the `.gitattributes`, because our tooling with otherwise miss it.  This is the only nodejs repo today that fits in this category. 