### PR TITLE
build: add an owlbot.py

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import synthtool as s
+import synthtool.gcp as gcp
+import synthtool.languages.node as node
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+common_templates = gcp.CommonTemplates()
+templates = common_templates.node_library()
+s.copy(templates)
+
+node.postprocess_gapic_library_hermetic()

--- a/owlbot.py
+++ b/owlbot.py
@@ -22,4 +22,4 @@ common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library()
 s.copy(templates)
 
-node.postprocess_gapic_library_hermetic()
+node.fix_hermetic()


### PR DESCRIPTION
The default owlbot.py behavior will not work on a repo that is not tracking an API surface in googleapis.