### PR TITLE
chore: add deprecation message in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [//]: # "This README.md file is auto-generated, all changes to this file will be lost."
 [//]: # "To regenerate it, use `python -m synthtool`."
+**_THIS PACKAGE IS DEPRECATED. PLEASE USE [OFFICIAL AUTH LIBRARY](https://www.npmjs.com/package/google-auth-library) AND MOCK IT, [EXAMPLE](https://github.com/googleapis/google-api-nodejs-client/pull/3849)_**
+
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
 # [Google Local Auth: Node.js Client](https://github.com/googleapis/nodejs-local-auth)

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "server-destroy": "^1.0.1"
   },
   "devDependencies": {
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10",
+    "@microsoft/api-documenter": "7.8.10",
+    "@microsoft/api-extractor": "7.8.10",
     "@types/mocha": "^9.0.0",
     "@types/nock": "^11.0.0",
     "@types/node": "^20.4.9",


### PR DESCRIPTION
Library was used for testing proposes, to avoid doing a mock of auth library. As part of the consolidation node packages project we are deprecating this.

If people need it, they can do something similar to https://github.com/googleapis/google-api-nodejs-client/pull/3849.
